### PR TITLE
full path comparison with cache

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ class RebuildChangedWebpackPlugin {
     return this.cache;
   }
 
-  hasToRebuildEntry(entryName, entryDependency) {
+  hasToRebuildEntry(context, entryDependency, entryName) {
     logger.log(`Rebuild ${entryName}?`);
     const cache = this.getCache();
     // No cached value for the entry -> we rebuild the entry
@@ -65,7 +65,7 @@ class RebuildChangedWebpackPlugin {
 
     // Check whether entrypoint file did change -> if yes: rebuild
     for (const dependency of singleEntryDependencies) {
-      const dependencyFile = dependency.request;
+      const dependencyFile = path.join(context, dependency.request);
       const entryMTime = this.getSyncMTimeForFilePath(dependencyFile);
 
       // Entry file modification time differs from cache -> rebuild
@@ -171,7 +171,7 @@ class RebuildChangedWebpackPlugin {
         // Patch addEntry from compilation object with cache filter
         compilation.addEntry = (context, dep, name, done) => {
           // Check whether we have to rebuild entry
-          if (this.hasToRebuildEntry(name, dep)) {
+          if (this.hasToRebuildEntry(context, dep, name)) {
             logger.log(`Rebuild ${name}`);
             // Entry or dependencies have changed -> rebuild entry
             actualAddEntry(context, dep, name, done);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rebuild-changed-entrypoints-webpack-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Webpack plugin that takes care of only rebuilding entrypoints that include changed files.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
In my case the plugin tried to rebuild always because it did not find any file in the cache array.

This patch helps. Please test your case too before merging. Thank you.